### PR TITLE
[TASK] Cast object to array to allow key() usage

### DIFF
--- a/Classes/Command/Component/SimpleComponentCommand.php
+++ b/Classes/Command/Component/SimpleComponentCommand.php
@@ -148,7 +148,7 @@ abstract class SimpleComponentCommand extends AbstractCommand
 
     protected function getPsr4Prefix(PackageInterface $package): string
     {
-        return (string)key(($package->getValueFromComposerManifest('autoload')->{'psr-4'} ?? []));
+        return (string)key((array)($package->getValueFromComposerManifest('autoload')->{'psr-4'} ?? []));
     }
 
     protected function getExtensionClassesPath(PackageInterface $package, string $psr4Prefix): string


### PR DESCRIPTION
Calling key() on an object directly is deprecated. Easiest fix, in this case, is to array-cast the psr-4 object.