### PR TITLE
[TASK] Temporarily remove roave/security-advisories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
     "typo3/cms-core": "^10.0 || ^11.0 || ^12.0"
   },
   "require-dev": {
-    "roave/security-advisories": "dev-master",
     "typo3/testing-framework": "^6.1",
     "typo3/coding-standards": "^0.4.0",
     "phpstan/phpstan": "^0.12.37",

--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,11 @@
     }
   ],
   "require": {
-    "typo3/cms-core": "^10.0 || ^11.0 || ^12.0"
+    "typo3/cms-core": "^10.0 || ^11.0 || ^12.0",
+    "enshrined/svg-sanitize": ">=0.15"
   },
   "require-dev": {
+    "roave/security-advisories": "dev-master",
     "typo3/testing-framework": "^6.1",
     "typo3/coding-standards": "^0.4.0",
     "phpstan/phpstan": "^0.12.37",

--- a/composer.json
+++ b/composer.json
@@ -17,11 +17,9 @@
     }
   ],
   "require": {
-    "typo3/cms-core": "^10.0 || ^11.0 || ^12.0",
-    "enshrined/svg-sanitize": ">=0.15"
+    "typo3/cms-core": "^10.0 || ^11.0 || ^12.0"
   },
   "require-dev": {
-    "roave/security-advisories": "dev-master",
     "typo3/testing-framework": "^6.1",
     "typo3/coding-standards": "^0.4.0",
     "phpstan/phpstan": "^0.12.37",


### PR DESCRIPTION
To fix the CI, we temporarily remove the `roave/security-advisories` package.

