### PR TITLE
[BUGFIX] Fix the "Edit on Github" button

### DIFF
--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -10,7 +10,7 @@ t3author = b13 GmbH
 
 github_branch = main
 github_repository = b13/make
-path_to_documentation_dir = README.md
+path_to_documentation_dir = /
 project_repository = https://github.com/b13/make
 
 # show as related links


### PR DESCRIPTION
It currently links to "https://github.com/b13/make/edit/main/README.mdREADME.rst"