### PR TITLE
[TASK] Add TYPO3 14 compatibility

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -32,18 +32,33 @@ jobs:
             php: '8.2'
           - TYPO3: '11'
             php: '8.3'
-          # TYPO3 12: PHP 8.1 - 8.3
+          # TYPO3 12: PHP 8.1 - 8.4
           - TYPO3: '12'
             php: '8.1'
           - TYPO3: '12'
             php: '8.2'
           - TYPO3: '12'
             php: '8.3'
-          # TYPO3 13: PHP 8.2 - 8.3
+          - TYPO3: '12'
+            php: '8.4'
+          # TYPO3 13: PHP 8.2 - 8.5
           - TYPO3: '13'
             php: '8.2'
           - TYPO3: '13'
             php: '8.3'
+          - TYPO3: '13'
+            php: '8.4'
+          - TYPO3: '13'
+            php: '8.5'
+          # TYPO3 14: PHP 8.2 - 8.5
+          - TYPO3: '14'
+            php: '8.2'
+          - TYPO3: '14'
+            php: '8.3'
+          - TYPO3: '14'
+            php: '8.4'
+          - TYPO3: '14'
+            php: '8.5'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -58,7 +58,7 @@ Options:
             - phpstan: phpstan analyze
             - unit (default): PHP unit tests
 
-    -t <10|11|12|13>
+    -t <10|11|12|13|14>
         Only with -s composerInstall|acceptance|functional
         TYPO3 core major version the extension is embedded in for testing.
 
@@ -69,7 +69,7 @@ Options:
             - postgres: use postgres
             - sqlite: use sqlite
 
-    -p <7.2|7.3|7.4|8.0|8.1|8.2|8.3>
+    -p <7.2|7.3|7.4|8.0|8.1|8.2|8.3|8.4|8.5>
         Specifies the PHP minor version to be used
             - 7.4 (default): use PHP 7.4
 
@@ -163,7 +163,7 @@ while getopts ":s:d:p:e:t:xy:nhuv" OPT; do
             ;;
         p)
             PHP_VERSION=${OPTARG}
-            if ! [[ ${PHP_VERSION} =~ ^(7.2|7.3|7.4|8.0|8.1|8.2|8.3)$ ]]; then
+            if ! [[ ${PHP_VERSION} =~ ^(7.2|7.3|7.4|8.0|8.1|8.2|8.3|8.4|8.5)$ ]]; then
                 INVALID_OPTIONS+=("${OPTARG}")
             fi
             ;;
@@ -299,10 +299,10 @@ case ${TEST_SUITE} in
         docker compose down
         ;;
     update)
-        # pull typo3/core-testing-*:latest versions of those ones that exist locally
-        docker images typo3/core-testing-*:latest --format "{{.Repository}}:latest" | xargs -I {} docker pull {}
+        # pull ghcr.io/typo3/core-testing-*:latest versions of those ones that exist locally
+        docker images ghcr.io/typo3/core-testing-*:latest --format "{{.Repository}}:latest" | xargs -I {} docker pull {}
         # remove "dangling" typo3/core-testing-* images (those tagged as <none>)
-        docker images typo3/core-testing-* --filter "dangling=true" --format "{{.ID}}" | xargs -I {} docker rmi {}
+        docker images ghcr.io/typo3/core-testing-* --filter "dangling=true" --format "{{.ID}}" | xargs -I {} docker rmi {}
         ;;
     *)
         echo "Invalid -s option argument ${TEST_SUITE}" >&2

--- a/Build/testing-docker/docker-compose.yml
+++ b/Build/testing-docker/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - /var/lib/postgresql/data:rw,noexec,nosuid
 
   web:
-    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    image: ghcr.io/typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
     user: "${HOST_UID}"
     stop_grace_period: 1s
     volumes:
@@ -46,7 +46,7 @@ services:
       "
 
   acceptance_backend_mariadb10:
-    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    image: ghcr.io/typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
     user: "${HOST_UID}"
     links:
       - mariadb10
@@ -89,7 +89,7 @@ services:
       "
 
   cgl:
-    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    image: ghcr.io/typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
     user: "${HOST_UID}"
     volumes:
       - ${CORE_ROOT}:${CORE_ROOT}
@@ -125,7 +125,7 @@ services:
       "
 
   composer_install:
-    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    image: ghcr.io/typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
     user: "${HOST_UID}"
     volumes:
       - ${CORE_ROOT}:${CORE_ROOT}
@@ -139,7 +139,13 @@ services:
           set -x
         fi
         php -v | grep '^PHP';
-        if [ ${TYPO3} -eq 11 ]; then
+        if [ ${TYPO3} -eq 13 ]; then
+          composer clear-cache
+          composer require typo3/cms-core:^13.4 typo3/testing-framework:^8 --dev -W --no-progress --no-interaction
+        elif [ ${TYPO3} -eq 12 ]; then
+          composer clear-cache
+          composer require typo3/cms-core:^12.4 --dev -W --no-progress --no-interaction
+        elif [ ${TYPO3} -eq 11 ]; then
           composer clear-cache
           composer require typo3/cms-core:^11.5 --dev -W --no-progress --no-interaction
         elif [ ${TYPO3} -eq 10 ]; then
@@ -148,12 +154,12 @@ services:
           composer prepare-tests-10
         else
           composer clear-cache
-          composer require typo3/cms-core:^12.4 --dev -W --no-progress --no-interaction
+          composer require typo3/cms-core:^14.2 typo3/testing-framework:^9 --dev -W --no-progress --no-interaction
         fi
       "
 
   composer_validate:
-    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    image: ghcr.io/typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
     user: "${HOST_UID}"
     volumes:
       - ${CORE_ROOT}:${CORE_ROOT}
@@ -171,7 +177,7 @@ services:
       "
 
   functional_mariadb10:
-    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    image: ghcr.io/typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
     user: "${HOST_UID}"
     links:
       - mariadb10
@@ -210,7 +216,7 @@ services:
       "
 
   functional_postgres10:
-    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    image: ghcr.io/typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
     user: "${HOST_UID}"
     links:
       - postgres10
@@ -250,7 +256,7 @@ services:
       "
 
   functional_sqlite:
-    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    image: ghcr.io/typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
     user: "${HOST_UID}"
     volumes:
       - ${CORE_ROOT}:${CORE_ROOT}
@@ -281,7 +287,7 @@ services:
       "
 
   lint:
-    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    image: ghcr.io/typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
     user: "${HOST_UID}"
     volumes:
       - ${CORE_ROOT}:${CORE_ROOT}
@@ -298,7 +304,7 @@ services:
       "
 
   phpstan:
-    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    image: ghcr.io/typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
     user: "${HOST_UID}"
     volumes:
       - ${CORE_ROOT}:${CORE_ROOT}
@@ -316,7 +322,7 @@ services:
       "
 
   unit:
-    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    image: ghcr.io/typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
     user: "${HOST_UID}"
     volumes:
       - ${CORE_ROOT}:${CORE_ROOT}

--- a/Classes/Command/ExtensionCommand.php
+++ b/Classes/Command/ExtensionCommand.php
@@ -160,7 +160,9 @@ class ExtensionCommand extends AbstractCommand
     {
         return (int)preg_replace_callback(
             '/^\^([0-9]{1,2}).*$/',
-            static function ($matches) { return $matches[1]; },
+            static function ($matches) {
+                return $matches[1];
+            },
             $versionConstraint
         );
     }

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You can also download the extension from the
 [TYPO3 Extension Repository](https://extensions.typo3.org/extension/make/)
 and activate it in the Extension Manager of your TYPO3 installation.
 
-Note: This extension is compatible with TYPO3 v10, v11, v12 and v13 and should
+Note: This extension is compatible with TYPO3 v10, v11, v12, v13 and v14 and should
 only be used in development context. So please make sure it is excluded
 for production releases.
 

--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,11 @@
     }
   ],
   "require": {
-    "typo3/cms-core": "^10.0 || ^11.0 || ^12.0 || ^13.0"
+    "typo3/cms-core": "^10.0 || ^11.0 || ^12.0 || ^13.0 || ^14.0"
   },
   "require-dev": {
     "phpstan/phpstan": "^1.4",
+    "phpunit/phpunit": "^8 || ^9 || ^10 || ^11",
     "typo3/cms-core": "^11.5",
     "typo3/coding-standards": "^0.5",
     "typo3/tailor": "^1.4",
@@ -33,6 +34,10 @@
     "allow-plugins": {
       "typo3/class-alias-loader": true,
       "typo3/cms-composer-installers": true
+    },
+    "audit": {
+      "block-insecure": false,
+      "block-abandoned": false
     }
   },
   "extra": {


### PR DESCRIPTION
Allow TYPO3 14 in composer.json and adapt the workflow and testing scripts to cover the updated core and PHP matrix.

This keeps automated checks compatible with the current TYPO3 testing framework setup.